### PR TITLE
Set gitignore to ignore /public/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sass-cache
 .start.pid
 .DS_Store
+public
 govuk_modules
 node_modules/*


### PR DESCRIPTION
The /public/ folder is auto-generated at runtime - a Grunt task cleans out the folder, then copies / builds all assets into it.
So we shouldn't version the contents.
