### PR TITLE
added link to the property prototype index page to main index page

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -19,6 +19,14 @@
 		</li>
 	</ul>
 
+	<h2 class="heading-large">Property page</h2>
+
+	<ul>
+		<li>
+			<a href="/property-page/">Property page index</a>
+		</li>
+	</ul>
+
   <h2 class="heading-large">Digital register - view iterations</h2>
   <p><a href="register-ab-research">Iterations to digital register view (web page) and register downloads (pdf).</a></p>
 


### PR DESCRIPTION
@Demotive hi just a small thing I remembered. I've added a new link to the property page prototypes index to the main index page just so that stuff is more discoverable without knowing the exact url.
